### PR TITLE
fix: don't display install banner when installed

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -14,6 +14,14 @@
         // app.baseUrl = '/polymer-starter-kit/';
     }
 
+    // don't display the install prompt if the user has *already* installed
+    window.addEventListener('beforeinstallprompt', function(event) {
+      if (window.matchMedia('(display-mode: standalone)').matches) {
+        return event.preventDefault();
+      }
+    });
+
+
     app.displayInstalledToast = function() {
         // Check to make sure caching is actually enabled—it won't be in the dev environment.
         if (!Polymer.dom(document).querySelector('platinum-sw-cache').disabled) {


### PR DESCRIPTION
I had this same error with https://jsconsole.com - after the user installed to their homescreen, when the app is launched, it asks to install again (snapdrop had the same issue).

This small tweak fixes it (though I'm not familiar with the polymer component, and I suspect I've done it in a non-polymer way - but it should still work).

Cheers so much - this app is my first real world install of a PWA - great work!