### PR TITLE
Update broken/moved links, package deps, and gulpfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 * [WebRTC](http://webrtc.org/)
   * [PeerJS](http://peerjs.com)
 * [WebSockets](http://www.websocket.org/) fallback (iDevices don't support WebRTC)
-  * [BinaryJs](http://binaryjs.com/)
+  * [BinaryJs](https://github.com/binaryjs/binaryjs)
 * [NodeJS](https://nodejs.org/en/)
-* [Material Design](http://www.google.com/design/spec/material-design/introduction.html)
+* [Material Design](https://material.google.com/)
 
 ### Frequently Asked Questions
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,7 @@ var ensureFiles = require('./tasks/ensure-files.js');
 var inlinesource = require('gulp-inline-source');
 var proxy = require('proxy-middleware');
 var url = require('url');
-var minifyHTML = require('gulp-minify-html');
+var minifyHTML = require('gulp-htmlmin');
 var replace = require('gulp-replace');
 
 // var ghPages = require('gulp-gh-pages');

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "gulp-autoprefixer": "^3.1.0",
     "gulp-cache": "^0.4.0",
     "gulp-changed": "^1.0.0",
+    "gulp-clean-css": "^2.0.13",
     "gulp-gh-pages": "^0.5.4",
     "gulp-html-extract": "^0.0.3",
+    "gulp-htmlmin": "^3.0.0",
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^2.2.1",
     "gulp-inline-source": "^2.1.0",
@@ -18,8 +20,6 @@
     "gulp-jscs-stylish": "^1.1.2",
     "gulp-jshint": "^1.6.3",
     "gulp-load-plugins": "^1.1.0",
-    "gulp-minify-css": "^1.2.1",
-    "gulp-minify-html": "^1.0.5",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.5.4",
     "gulp-size": "^2.0.0",
@@ -49,6 +49,6 @@
     "express": "^4.13.3",
     "peer": "^0.2.8",
     "ua-parser-js": "^0.7.10",
-    "ws": "^0.8.1"
+    "ws": "^1.1.1"
   }
 }


### PR DESCRIPTION
- Update link to binaryjs, as their website seems to be down
- Update Material Design link
- Replace `gulp-minify-css` and `gulp-minify-html`, they have been deprecated
- Update ws [#1](https://nodesecurity.io/advisories/ws_buffer-leak), [#2](https://nodesecurity.io/advisories/socketio_dos-due-to-excessively-large-websocket-message)