### PR TITLE
Temporary fixes to reproducing a proper `gulp serve`

### DIFF
--- a/tasks/ensure-files.js
+++ b/tasks/ensure-files.js
@@ -1,0 +1,34 @@
+var fs = require('fs');
+
+/**
+ * @param {Array<string>} files
+ * @param {Function} cb
+ */
+
+function ensureFiles(files, cb) {
+  var missingFiles = files.reduce(function(prev, filePath) {
+    var fileFound = false;
+
+    try {
+      fileFound = fs.statSync(filePath).isFile();
+    } catch (e) { }
+
+    if (!fileFound) {
+      prev.push(filePath + ' Not Found');
+    }
+
+    return prev;
+  }, []);
+
+  if (missingFiles.length) {
+    var err = new Error('Missing Required Files\n' + missingFiles.join('\n'));
+  }
+
+  if (cb) {
+    cb(err);
+  } else if (err) {
+    throw err;
+  }
+}
+
+module.exports = ensureFiles;


### PR DESCRIPTION
This fixes the issue where `gulp serve` would just fail.

The code is extremely messy, and tasks like `gulp html`, `gulp lint`, and `gulp vulcanize` have not been fixed yet.