### PR TITLE
Fix bug where clients try to re-answer established connections.

### DIFF
--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -273,8 +273,14 @@ class RTCPeer extends Peer {
 
         if (message.sdp) {
             this._conn.setRemoteDescription(new RTCSessionDescription(message.sdp))
-                .then( _ => this._conn.createAnswer())
-                .then(d => this._onDescription(d))
+                .then( _ => {
+                    if (message.sdp.type == 'offer') {
+                        return this._conn.createAnswer()
+                            .then(d => this._onDescription(d));
+                    } else {
+                        return null;
+                    }
+                })
                 .catch(e => this._onError(e));
         } else if (message.ice) {
             this._conn.addIceCandidate(new RTCIceCandidate(message.ice));


### PR DESCRIPTION
When setting up a WebRTC connection between two clients, the `onServerMessage()` method gets called twice - once with a WebRTC offer, and once with the answer to the offer. Calling `createAnswer()` only works in the browser that is receiving the offer. This PR avoids calling `createAnswer()` when an answer has just been received.