### PR TITLE
Enable standalone display mode (PWA)

### DIFF
--- a/client/manifest.json
+++ b/client/manifest.json
@@ -24,7 +24,7 @@
     }],
     "background_color": "#efefef",
     "start_url": "/",
-    "display": "minimal-ui",
+    "display": "standalone",
     "theme_color": "#3367d6",
     "share_target": {
         "action": "/?share_target",


### PR DESCRIPTION
Changed `display: "minimal-ui"` to `"standalone"`. There doesn't seem to be any reason to keep the `minimal-ui`: no need for a browser back button or similar. This change will also now allow Chrome on mobile to show the Add to Home Screen banner, which does not show with `minimal-ui`.

Fixes #93 