### PR TITLE
No webapp at the moment for iOS

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,7 +8,8 @@
     <title>Snapdrop</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#3367d6">
-    <meta name="apple-mobile-web-app-capable" content="no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="white"> 
     <meta name="apple-mobile-web-app-title" content="Snapdrop">
     <!-- Descriptions -->
     <meta property="og:title" content="Snapdrop">


### PR DESCRIPTION
Is there a reason why `apple-mobile-web-app-capable` is set to `no`? This results in the whole `<!-- Web App Config -->` section being unnecessary since this results in there being no web-app. Therefore snapdrop is opened in Safari all the time on iOS if placed on the home screen. So I would suggest to change this value in order to give a better experience. If this would be switched to `yes` I have also added the `apple-mobile-web-app-status-bar-style` so the status bar will conform to the app-UI.