### PR TITLE
Session storage for peerId (as discussed in #144)

### DIFF
--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -57,16 +57,26 @@ class ServerConnection {
     _peerId() {
         let peerId = sessionStorage.getItem("peerid");
         if (!peerId) {
-            // 128 random bytes, modulo'd into 0-9A-Za-z
-            const rand = crypto.getRandomValues(new Uint8Array(128))
-                .map(x => {
-                    x %= 60;
-                    if (x > 35) x += 61; // a-z
-                    else if (x > 9) x += 55; // A-Z
-                    else x += 48; // 0-9
-                    return x;
-                });
-            peerId = new TextDecoder("ascii").decode(rand);
+            peerId = '';
+            for (let ii = 0; ii < 32; ii += 1) {
+                switch (ii) {
+                    case 8:
+                    case 20:
+                        peerId += '-';
+                        peerId += (Math.random() * 16 | 0).toString(16);
+                        break;
+                    case 12:
+                        peerId += '-';
+                        peerId += '4';
+                        break;
+                    case 16:
+                        peerId += '-';
+                        peerId += (Math.random() * 4 | 8).toString(16);
+                        break;
+                    default:
+                        peerId += (Math.random() * 16 | 0).toString(16);
+                }
+            }
             sessionStorage.setItem("peerid", peerId);
         }
         return peerId;

--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -13,7 +13,7 @@ class ServerConnection {
     _connect() {
         clearTimeout(this._reconnectTimer);
         if (this._isConnected() || this._isConnecting()) return;
-        const ws = new WebSocket(this._endpoint());
+        const ws = new WebSocket(this._endpoint() + "?peerid=" + this._peerId());
         ws.binaryType = 'arraybuffer';
         ws.onopen = e => console.log('WS: server connected');
         ws.onmessage = e => this._onMessage(e.data);
@@ -52,6 +52,24 @@ class ServerConnection {
     send(message) {
         if (!this._isConnected()) return;
         this._socket.send(JSON.stringify(message));
+    }
+
+    _peerId() {
+        let peerId = sessionStorage.getItem("peerid");
+        if (!peerId) {
+            // 128 random bytes, modulo'd into 0-9A-Za-z
+            const rand = crypto.getRandomValues(new Uint8Array(128))
+                .map(x => {
+                    x %= 60;
+                    if (x > 35) x += 61; // a-z
+                    else if (x > 9) x += 55; // A-Z
+                    else x += 48; // 0-9
+                    return x;
+                });
+            peerId = new TextDecoder("ascii").decode(rand);
+            sessionStorage.setItem("peerid", peerId);
+        }
+        return peerId;
     }
 
     _endpoint() {

--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,6 @@ class SnapdropServer {
         const WebSocket = require('ws');
         this._wss = new WebSocket.Server({ port: port });
         this._wss.on('connection', (socket, request) => this._onConnection(new Peer(socket, request)));
-        this._wss.on('headers', (headers, response) => this._onHeaders(headers, response));
 
         this._rooms = {};
 
@@ -21,12 +20,6 @@ class SnapdropServer {
 
         // send displayName
         this._send(peer, { type: 'displayName', message: peer.name.displayName });
-    }
-
-    _onHeaders(headers, response) {
-        if (response.headers.cookie && response.headers.cookie.indexOf('peerid=') > -1) return;
-        response.peerId = Peer.uuid();
-        headers.push('Set-Cookie: peerid=' + response.peerId + "; SameSite=Strict; Secure");
     }
 
     _onMessage(sender, message) {
@@ -174,11 +167,7 @@ class Peer {
     }
 
     _setPeerId(request) {
-        if (request.peerId) {
-            this.id = request.peerId;
-        } else {
-            this.id = request.headers.cookie.replace('peerid=', '');
-        }
+        this.id = new URL(request.url, "http://server").searchParams.get("peerid");
     }
 
     toString() {
@@ -203,32 +192,6 @@ class Peer {
             rtcSupported: this.rtcSupported
         }
     }
-
-    // return uuid of form xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
-    static uuid() {
-        let uuid = '',
-            ii;
-        for (ii = 0; ii < 32; ii += 1) {
-            switch (ii) {
-                case 8:
-                case 20:
-                    uuid += '-';
-                    uuid += (Math.random() * 16 | 0).toString(16);
-                    break;
-                case 12:
-                    uuid += '-';
-                    uuid += '4';
-                    break;
-                case 16:
-                    uuid += '-';
-                    uuid += (Math.random() * 4 | 8).toString(16);
-                    break;
-                default:
-                    uuid += (Math.random() * 16 | 0).toString(16);
-            }
-        }
-        return uuid;
-    };
 }
 
 const server = new SnapdropServer(process.env.PORT || 3000);


### PR DESCRIPTION
This basically moves the peerId into a query param of the connection rather than a Cookie. This means the client has control over how long it remains the same client.

I've moved the storage of the peerId to `sessionStorage` so that two browser tabs can connect and operate independently. The intention of then being able to share to two different people online, by suing two browser tabs.

Since the peerId isn't actually used for anything much currently (as mentioned in #127 )... the other option would be to make it completely ephemeral: see https://github.com/willstott101/snapdrop/commit/56ab2357a66797e56db1dfb489eda32150f8d3a5
