### PR TITLE
Add support for SIGINT and SIGTERM handling

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,16 @@
+var process = require('process')
+// Handle SIGINT
+process.on('SIGINT', () => {
+  console.info("SIGINT Received, exiting...")
+  process.exit(0)
+})
+
+// Handle SIGTERM
+process.on('SIGTERM', () => {
+  console.info("SIGTERM Received, exiting...")
+  process.exit(0)
+})
+
 const parser = require('ua-parser-js');
 const { uniqueNamesGenerator, animals, colors } = require('unique-names-generator');
 


### PR DESCRIPTION
Currently, server run by `node index.js` is not able to handle SIGTERM or SIGINT properly. The only fate is being killed. This change adds basic handling logic for these two signals, helping server to behave more properly as expected by many daemons and users.