### PR TITLE
Fix broken FAQ link

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -141,7 +141,7 @@
                         <use xlink:href="#twitter" />
                     </svg>
                 </a>
-                <a class="icon-button" target="_blank" href="https://github.com/RobinLinus/snapdrop/docs/faq.md" title="Frequently asked questions" rel="noreferrer">
+                <a class="icon-button" target="_blank" href="https://github.com/RobinLinus/snapdrop/blob/master/docs/faq.md" title="Frequently asked questions" rel="noreferrer">
                     <svg class="icon">
                         <use xlink:href="#help-outline" />
                     </svg>


### PR DESCRIPTION
 Fixes broken FAQ link which currently returns Not Found. 

BTW the server image probably needs to be updated (after merging this PR) as currently the link to the _new_ FAQ page isn't there at all, but still the old one which points to the README...