### PR TITLE
Enable file sharing outside the network by grouping peers by room id and not IP (requested #199)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -56,10 +56,13 @@
             </svg>
         </a>
     </header>
+    <x-qr class="center">
+
+    </x-qr>
     <!-- Peers -->
     <x-peers class="center"></x-peers>
     <x-no-peers>
-        <h2>Open Snapdrop on other devices to send files</h2>
+        <h2>Scan the QR code or share this url to open Snapdrop on other devices to send files</h2>
     </x-no-peers>
     <x-instructions desktop="Click to send files or right click to send a message" mobile="Tap to send files or long tap to send a message"></x-instructions>
     <!-- Footer -->
@@ -79,7 +82,7 @@
                 <div class="font-body2" id="fileSize"></div>
                 <div class="row">
                     <label for="autoDownload" class="grow">Ask to save each file before downloading</label>
-                    <input type="checkbox" id="autoDownload" checked=""> 
+                    <input type="checkbox" id="autoDownload" checked="">
                 </div>
                 <div class="row-reverse">
                     <a class="button" close id="download" title="Download File" autofocus>Save</a>

--- a/client/styles.css
+++ b/client/styles.css
@@ -176,6 +176,15 @@ body>header a {
     margin-left: 8px;
 }
 
+x-qr {
+    border-radius: 4px;
+    overflow: hidden;
+    margin: 16px;
+    animation: fade-in 300ms;
+    animation-delay: 500ms;
+    animation-fill-mode: backwards;
+}
+
 /* Peers List */
 
 x-peers {
@@ -679,8 +688,8 @@ screen and (min-width: 1100px) {
     }
 }
 
-/* 
-    Color Themes 
+/*
+    Color Themes
 */
 
 /* Default colors */

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -9,7 +9,7 @@ server {
 
     location / {
         root   /usr/share/nginx/html;
-        index  index.html index.htm;
+        try_files $uri $uri/ /index.html =404;
     }
 
     location /server {
@@ -49,6 +49,7 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
+        try_files $uri $uri/ /index.html =404;
     }
 
     location /server {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "hashids": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/hashids/-/hashids-2.2.8.tgz",
+      "integrity": "sha512-OI6rsk/OqyX60nBsqxnNl3R7CDv9eMOgxzipshZwXE6cUcBcEyHf8rNDlWVdQJZK3TEynILYybCsNUEQfJsdLA=="
+    },
     "ua-parser-js": {
       "version": "0.7.21",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "hashids": "^2.2.8",
     "ua-parser-js": "^0.7.21",
     "unique-names-generator": "^4.3.0",
     "ws": "^7.3.1"


### PR DESCRIPTION
I have a use case were I want to share photos with my friends on the go without loosing the image quality (Whatsapp, Facebook) and without the hassle of a shared network (both peers are using their own cellular network). This pull request is a POC where files can be shared with remote peers.

Currently the signaling server groups all peers in rooms by their IP-address.  All peers in the same room are discoverable to each other. Instead of the server grouping peers based on their IP all peers join a room explicitly using an identifier. The room identifier is a [short hashid](https://github.com/niieani/hashids.js). This enables peers to join the room on an URL basis. eg snapdrop.net/<shorthash>.  A QR-code is displayed for quick mobile device access.

What do you think of this direction? 