### PR TITLE
Assign a default SDP Semantics

### DIFF
--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -509,6 +509,7 @@ class Events {
 
 
 RTCPeer.config = {
+    'sdpSemantics': 'unified-plan',
     'iceServers': [{
         urls: 'stun:stun.l.google.com:19302'
     }]


### PR DESCRIPTION
I am not really sure if this is the right way or what, but I am
unable to send nor receive files on a Windows 10 computer, but my
other devices (not Windows 10) can use snapdrop just fine.

Using the unified plan SDP Semantics I got snapdrop to work, the
other option is 'plan b', but I don't know much about this.

The following issues might be related to this: #177 #164 #168 #171 #186 #188 #190

This stackoverflow post made me test this:
https://stackoverflow.com/questions/55378987/failed-to-execute-setremotedescription-on-rtcpeerconnection-failed-to-set-r