### PR TITLE
Updated ui.js animation stop timeout because of a bad show on portrait mode

### DIFF
--- a/client/scripts/ui.js
+++ b/client/scripts/ui.js
@@ -27,7 +27,7 @@ class PeersUI {
         if ($(peer.id)) return; // peer already exists
         const peerUI = new PeerUI(peer);
         $$('x-peers').appendChild(peerUI.$el);
-        setTimeout(e => window.animateBackground(false), 1000); // Stop animation
+        setTimeout(e => window.animateBackground(false), 1750); // Stop animation
     }
 
     _onPeers(peers) {


### PR DESCRIPTION
I've changed the timeout time from 1000ms to 1750ms because, when there is someone already connected to Snapdrop, when Snapdrop is loaded by a portrait mode device, the time is not enough to view the background effect in all the screen.
Below an iPad example:

![example](https://user-images.githubusercontent.com/72039923/105033821-e7f2c100-5a58-11eb-847c-1988790c30a2.jpeg)
