### PR TITLE
Removed drag to reload thing

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -20,6 +20,7 @@ body {
     flex-direction: column;
     width: 100%;
     overflow-x: hidden;
+    overscroll-behavior-y: none;
 }
 
 body {
@@ -528,10 +529,10 @@ button::-moz-focus-inner {
 
 #about x-background {
     position: absolute;
-    top: calc(32px - 200px);
-    right: calc(32px - 200px);
-    width: 400px;
-    height: 400px;
+    top: calc(32px - 500px);
+    right: calc(32px - 500px);
+    width: 1000px;
+    height: 1000px;
     border-radius: 50%;
     background: var(--primary-color);
     transform: scale(0);


### PR DESCRIPTION
Solves #253. Yeah that's quite annoying.
Also made about page background width and height bigger. 
On 400px causes the background on 1080p screens to not scale properly. I thought about it for a while. What would it look like on a 4k screen? We might have to find a way to properly scale the background on all screen sizes.

Have a safe week. Damn, actually I should say have a safe and happy rest of 2021.