### PR TITLE
Capitalize "d" in "Docker"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Have any questions? Read our [FAQ](/docs/faq.md).
 
-You can [host your own instance with docker](/docs/local-dev.md).
+You can [host your own instance with Docker](/docs/local-dev.md).
 
 
 ## Support the Snapdrop Community


### PR DESCRIPTION
Docker is the name for a technology. Therefore, the name should be capitalized as a proper noun.