### PR TITLE
Added standalone PWA for iOS 13 and higher

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#3367d6">
     <meta name="color-scheme" content="dark light">
-    <meta name="apple-mobile-web-app-capable" content="no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-title" content="Snapdrop">
     <!-- Descriptions -->
     <meta name="description" content="Instantly share images, videos, PDFs, and links with people nearby. Peer2Peer and Open Source. No Setup, No Signup.">
@@ -33,7 +33,7 @@
     <meta property="og:image" content="https://snapdrop.net/images/twitter-stream.jpg">
     <!-- Resources -->
     <link rel="stylesheet" type="text/css" href="styles.css">
-    <link rel="manifest" href="manifest.json">
+    <link rel="manifest" id="manifest-placeholder">
 </head>
 
 <body translate="no">
@@ -213,6 +213,7 @@
     <script src="scripts/ui.js"></script>
     <script src="scripts/theme.js" async></script>
     <script src="scripts/clipboard.js" async></script>
+    <script src="scripts/manifest.js" async></script>
     <!-- Sounds -->
     <audio id="blop" autobuffer="true">
         <source src="/sounds/blop.mp3" type="audio/mpeg">

--- a/client/scripts/manifest.js
+++ b/client/scripts/manifest.js
@@ -1,4 +1,4 @@
-{
+const content = {
     "name": "Snapdrop",
     "short_name": "Snapdrop",
     "icons": [{
@@ -26,7 +26,7 @@
     }],
     "background_color": "#efefef",
     "start_url": "/",
-    "display": "minimal-ui",
+    "display": "standalone",
     "theme_color": "#3367d6",
     "share_target": {
         "method":"GET",
@@ -38,3 +38,18 @@
         }
     }
 }
+
+const iOSversion = parseFloat(
+	('' + (/CPU.*OS ([0-9_]{1,5})|(CPU like).*AppleWebKit.*Mobile/i.exec(navigator.userAgent) || [0,''])[1])
+	.replace('undefined', '3_2').replace('_', '.').replace('_', '')
+) || false;
+
+
+if (iOSversion && iOSversion < 13) {
+    content["display"] = "minimal-ui";
+}
+
+const stringManifest = JSON.stringify(content);
+const blob = new Blob([stringManifest], {type: 'application/json'});
+const manifestURL = URL.createObjectURL(blob);
+document.querySelector('#manifest-placeholder').setAttribute('href', manifestURL);


### PR DESCRIPTION
Moved the manifest.json file to a manifest.js file to allow change based on iOS version.

The default mode is now standalone unless iOS version is less than 13 (the apps works with iOS 13 and higher).

The patch was not tested with iPad versions and Android