### PR TITLE
Make the pwa run as an app

### DIFF
--- a/client/manifest.json
+++ b/client/manifest.json
@@ -26,7 +26,7 @@
     }],
     "background_color": "#efefef",
     "start_url": "/",
-    "display": "minimal-ui",
+    "display": "standalone",
     "theme_color": "#3367d6",
     "share_target": {
         "method":"GET",


### PR DESCRIPTION
I've changed the display mode from minimal-ui to standalone so the pwa won't be opened in the browser but as a seperate app.