### PR TITLE
Make socket location relative to location snapdrop client was served from

### DIFF
--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -58,7 +58,7 @@ class ServerConnection {
         // hack to detect if deployment or development environment
         const protocol = location.protocol.startsWith('https') ? 'wss' : 'ws';
         const webrtc = window.isRtcSupported ? '/webrtc' : '/fallback';
-        const url = protocol + '://' + location.host + '/server' + webrtc;
+        const url = protocol + '://' + location.host + location.pathname + '/server' + webrtc;
         return url;
     }
 


### PR DESCRIPTION
This change makes snapdrop client look for its web socket relative to where the client page was served from, this makes it so the client can be proxied from URLs other than /.  It's needed so that the client can be proxied by home assistant (which exposes the container under a path and /server does not work to find the socket).