### PR TITLE
Resolve image too big bug modifying style

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -718,9 +718,9 @@ x-dialog x-paper {
 }
 /* Image Preview */
 #img-preview{
-    max-width:100%;
-    max-height:100%;
-   
+    max-height: 50vh;
+    margin: auto;
+    display: block;
 }
 
 


### PR DESCRIPTION
The previous version of Snapdrop with images preview, had a bug when transferring big (vertical) images that hided download button. These changes should resolve the issue (I'm not very expert with CSS, if anyone have some proposes, let me know).

Closes #338 and #352.