### PR TITLE
fix bug: sender endlessly sends empty data

### DIFF
--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -465,7 +465,7 @@ class FileChunker {
     }
 
     isFileEnd() {
-        return this._offset > this._file.size;
+        return this._offset >= this._file.size;
     }
 
     get progress() {


### PR DESCRIPTION
[fa1ff95](https://github.com/RobinLinus/snapdrop/commit/fa1ff959656ead380ed99c9955b9648506538e8c) just prevents receiver receiving data, but the sender are still sending data.

The real bug may be file-end-check function `isFileEnd ` in class `FileChunker`.