### PR TITLE
Fix notification click to copy function.

### DIFF
--- a/client/scripts/clipboard.js
+++ b/client/scripts/clipboard.js
@@ -1,6 +1,6 @@
 // Polyfill for Navigator.clipboard.writeText
-if (!navigator.clipboard) {
-    navigator.clipboard = {
+if (!navigator.clipboard) { navigator.clipboard = newClipboard; }
+    newClipboard = {
         writeText: text => {
 
             // A <span> contains the text to copy
@@ -32,7 +32,6 @@ if (!navigator.clipboard) {
             selection.removeAllRanges();
             span.remove();
 
-            return Promise.resolve();
+            return success ? Promise.resolve() : false;
         }
     }
-}

--- a/client/scripts/ui.js
+++ b/client/scripts/ui.js
@@ -465,8 +465,7 @@ class Notifications {
 
     _copyText(message, notification) {
         notification.close();
-        if (!navigator.clipboard.writeText(message)) return;
-        this._notify('Copied text to clipboard');
+        newClipboard.writeText(message) ? this._notify('Copied text to clipboard') : this._notify('Copy failed, please return web page to copy.');
     }
 
     _bind(notification, handler) {


### PR DESCRIPTION
Fix notification click to copy text function.
Now the function works, but only works with blink core desktop browsers.