### PR TITLE
fix: fix newline duplication on text share

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -100,7 +100,14 @@
             <x-background class="full center">
                 <x-paper shadow="2">
                     <h3>Send a Message</h3>
-                    <div id="textInput" class="textarea" role="textbox" placeholder="Send a message" autocomplete="off" autofocus contenteditable></div>
+
+					<div class="textarea">
+						<!-- use `!` to preserve spacing when empty -->
+						<div id="textDouble" class="textDouble" aria-hidden="true">!</div>
+
+						<textarea id="textInput" class="textInput" placeholder="Send a message" autocomplete="off" autofocus></textarea>
+					</div>
+
                     <div class="row-reverse">
                         <button class="button" type="submit" close>Send</button>
                         <a class="button" close>Cancel</a>

--- a/client/scripts/ui.js
+++ b/client/scripts/ui.js
@@ -315,6 +315,21 @@ class SendTextDialog extends Dialog {
         super('sendTextDialog');
         Events.on('text-recipient', e => this._onRecipient(e.detail))
         this.$text = this.$el.querySelector('#textInput');
+
+		// `textDouble`, an invisible element with `opacity: 0` and `aria-hidden="true"`,
+		// is kept in sync with `this.$text` to automatically expand the parent element size
+		// in line with the number of rows in the textarea. This approach is preferable to
+		// using a <div contenteditable> with `innerText` to avoid various issues in the
+		// `contentEditable` and `innerText` browser APIs, such as newlines being duplicated.
+		// See e.g. https://stackoverflow.com/questions/56535416/innertext-on-content-editable-doubling-some-line-breaks
+		const textDouble = this.$el.querySelector('#textDouble');
+
+		this.$text.addEventListener('input', e => {
+			// use `!` to preserve spacing when last line is empty
+			textDouble.textContent = e.currentTarget.value
+				.replace(/(^|\n)$/, '$1!');
+		});
+
         const button = this.$el.querySelector('form');
         button.addEventListener('submit', e => this._send(e));
     }
@@ -330,7 +345,6 @@ class SendTextDialog extends Dialog {
         range.selectNodeContents(this.$text);
         sel.removeAllRanges();
         sel.addRange(range);
-
     }
 
     _handleShareTargetText() {
@@ -343,7 +357,7 @@ class SendTextDialog extends Dialog {
         e.preventDefault();
         Events.fire('send-text', {
             to: this._recipient,
-            text: this.$text.innerText
+            text: this.$text.value
         });
     }
 }

--- a/client/styles.css
+++ b/client/styles.css
@@ -669,12 +669,12 @@ screen and (min-width: 1100px) {
     }
 }
 
-/* 
+/*
     iOS specific styles
 */
 @supports (-webkit-overflow-scrolling: touch) {
 
-    
+
     html {
         position: fixed;
     }
@@ -713,10 +713,43 @@ x-dialog x-paper {
     background-color: var(--bg-color);
 }
 
+/* Textarea */
 .textarea {
     color: var(--text-color);
     background-color: var(--bg-color-secondary);
+    position: relative;
+	overflow-wrap: break-word;
 }
+
+.textarea .textDouble {
+	font-size: inherit;
+	line-height: inherit;
+    opacity: 0;
+	white-space: pre-wrap;
+}
+
+.textarea .textInput {
+	font-size: inherit;
+	line-height: inherit;
+    padding: inherit;
+	font-family: inherit;
+	border: none;
+	outline: none;
+    width: 100%;
+	height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    box-sizing: border-box;
+    background: none;
+    overflow: hidden;
+    margin: 0;
+	white-space: pre-wrap;
+	resize: none;
+}
+
 /* Image Preview */
 #img-preview{
     max-height: 50vh;
@@ -744,7 +777,7 @@ x-dialog x-paper {
 }
 
 
-/* 
+/*
     Edge specific styles
 */
 @supports (-ms-ime-align: auto) {


### PR DESCRIPTION
Fixes https://github.com/RobinLinus/snapdrop/issues/408:

> Each occurrence of \n\n is converted to \n\n\n when sending a message using the "right click/long press to send a message" feature.

This was due to an inconsistency between the `contenteditable` and `innerText` browser APIs, which causes empty lines to be rendered using the HTML `<div><br></div>`, which `innerText` reads as `\n\n` rather than `\n`; hence `one\n\ntwo` becomes `<div>one</div><div><br></div><div>two</div>`, which then becomes `one\n\n\ntwo`.

Fixed by replacing the `<div contenteditable>` with a normal `<textarea>`, which is backed by `#textDouble`, an invisible element with `opacity: 0` and `aria-hidden="true"`, in order to retain the automatic resizing of the parent element in line with the number of rows in the textarea.