### PR TITLE
Added dynamic manifest changing for iOS devices

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -214,6 +214,7 @@
     <!-- Scripts -->
     <script src="scripts/network.js"></script>
     <script src="scripts/ui.js"></script>
+    <script src="scripts/manifest.js"></script>
     <script src="scripts/theme.js" async></script>
     <script src="scripts/clipboard.js" async></script>
     <!-- Sounds -->

--- a/client/manifest-ios.json
+++ b/client/manifest-ios.json
@@ -26,7 +26,7 @@
     }],
     "background_color": "#efefef",
     "start_url": "/",
-    "display": "standalone",
+    "display": "minimal-ui",
     "theme_color": "#3367d6",
     "share_target": {
         "method":"GET",

--- a/client/scripts/manifest.js
+++ b/client/scripts/manifest.js
@@ -1,0 +1,4 @@
+
+if (window.iOS) {
+	document.querySelector('link[rel="manifest"]').setAttribute('href', 'manifest-ios.json')
+}


### PR DESCRIPTION
As you know, the PWA is set to have minimal-ui since on iOS downloads break. I've added dynamic manifest changing so that it switches the manifest when iOS is detected. Should work on all browsers, but I didn't test too thoroughly. The current implementation changes the normal manifest with a manifest that sets display to minimal-ui. On Safari, this change might not get recognized immediately. So we might have to do this manifest change reversed: keep minimal-ui manifest and when detecting a device that is not iOS change to standalone display. Almost all browsers recognize this change immediately, but I have some doubts with Safari. Any thoughts on how to improve this?