### PR TITLE
QoL: avoid image overflow container

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -720,6 +720,7 @@ x-dialog x-paper {
 /* Image Preview */
 #img-preview{
     max-height: 50vh;
+    max-width: 100%;
     margin: auto;
     display: block;
 }


### PR DESCRIPTION
Before change:
<img width="571" alt="Screen Shot 2022-09-13 at 01 29 39" src="https://user-images.githubusercontent.com/10842569/189816619-6e95c3d5-58dd-4364-aa80-930524b9febc.png">

After change:
<img width="571" alt="Screen Shot 2022-09-13 at 01 29 54" src="https://user-images.githubusercontent.com/10842569/189816656-f0fe3836-a831-4b7e-8d5d-77071087d001.png">
