### PR TITLE
JS, HTML and CSS fmt + NPM lockfile version bump

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,215 +1,333 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <!-- Web App Config -->
     <title>Snapdrop</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <meta name="theme-color" content="#3367d6">
-    <meta name="color-scheme" content="dark light">
-    <meta name="apple-mobile-web-app-capable" content="no">
-    <meta name="apple-mobile-web-app-title" content="Snapdrop">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, user-scalable=no"
+    />
+    <meta name="theme-color" content="#3367d6" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="apple-mobile-web-app-capable" content="no" />
+    <meta name="apple-mobile-web-app-title" content="Snapdrop" />
     <!-- Descriptions -->
-    <meta name="description" content="Instantly share images, videos, PDFs, and links with people nearby. Peer2Peer and Open Source. No Setup, No Signup.">
-    <meta name="keywords" content="File, Transfer, Share, Peer2Peer">
-    <meta name="author" content="RobinLinus">
-    <meta property="og:title" content="Snapdrop">
-    <meta property="og:type" content="article">
-    <meta property="og:url" content="https://snapdrop.net/">
-    <meta property="og:author" content="https://facebook.com/RobinLinus">
-    <meta name="twitter:author" content="@RobinLinus">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:description" content="Instantly share images, videos, PDFs, and links with people nearby. Peer2Peer and Open Source. No Setup, No Signup.">
-    <meta name="og:description" content="Instantly share images, videos, PDFs, and links with people nearby. Peer2Peer and Open Source. No Setup, No Signup.">
+    <meta
+      name="description"
+      content="Instantly share images, videos, PDFs, and links with people nearby. Peer2Peer and Open Source. No Setup, No Signup."
+    />
+    <meta name="keywords" content="File, Transfer, Share, Peer2Peer" />
+    <meta name="author" content="RobinLinus" />
+    <meta property="og:title" content="Snapdrop" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://snapdrop.net/" />
+    <meta property="og:author" content="https://facebook.com/RobinLinus" />
+    <meta name="twitter:author" content="@RobinLinus" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:description"
+      content="Instantly share images, videos, PDFs, and links with people nearby. Peer2Peer and Open Source. No Setup, No Signup."
+    />
+    <meta
+      name="og:description"
+      content="Instantly share images, videos, PDFs, and links with people nearby. Peer2Peer and Open Source. No Setup, No Signup."
+    />
     <!-- Icons -->
-    <link rel="icon" sizes="96x96" href="images/favicon-96x96.png">
-    <link rel="shortcut icon" href="images/favicon-96x96.png">
-    <link rel="apple-touch-icon" href="images/apple-touch-icon.png">
-    <meta name="msapplication-TileImage" content="images/mstile-150x150.png">
-    <link rel="fluid-icon" type="image/png" href="images/android-chrome-192x192.png">
-    <meta name="twitter:image" content="https://snapdrop.net/images/twitter-stream.jpg">
-    <meta property="og:image" content="https://snapdrop.net/images/twitter-stream.jpg">
+    <link rel="icon" sizes="96x96" href="images/favicon-96x96.png" />
+    <link rel="shortcut icon" href="images/favicon-96x96.png" />
+    <link rel="apple-touch-icon" href="images/apple-touch-icon.png" />
+    <meta name="msapplication-TileImage" content="images/mstile-150x150.png" />
+    <link
+      rel="fluid-icon"
+      type="image/png"
+      href="images/android-chrome-192x192.png"
+    />
+    <meta
+      name="twitter:image"
+      content="https://snapdrop.net/images/twitter-stream.jpg"
+    />
+    <meta
+      property="og:image"
+      content="https://snapdrop.net/images/twitter-stream.jpg"
+    />
     <!-- Resources -->
-    <link rel="stylesheet" type="text/css" href="styles.css">
-    <link rel="manifest" href="manifest.json">
-</head>
+    <link rel="stylesheet" type="text/css" href="styles.css" />
+    <link rel="manifest" href="manifest.json" />
+  </head>
 
-<body translate="no">
+  <body translate="no">
     <header class="row-reverse">
-        <a href="#about" class="icon-button" title="About Snapdrop">
-            <svg class="icon">
-                <use xlink:href="#info-outline" />
-            </svg>
-        </a>
-        <a href="#" id="theme" class="icon-button" title="Switch Darkmode/Lightmode" >
-            <svg class="icon">
-                <use xlink:href="#icon-theme" />
-            </svg>
-        </a>
-        <a href="#" id="notification" class="icon-button" title="Enable Notifications" hidden>
-            <svg class="icon">
-                <use xlink:href="#notifications" />
-            </svg>
-        </a>
-        <a href="#" id="install" class="icon-button" title="Install Snapdrop" hidden>
-            <svg class="icon">
-                <use xlink:href="#homescreen" />
-            </svg>
-        </a>
+      <a href="#about" class="icon-button" title="About Snapdrop">
+        <svg class="icon">
+          <use xlink:href="#info-outline" />
+        </svg>
+      </a>
+      <a
+        href="#"
+        id="theme"
+        class="icon-button"
+        title="Switch Darkmode/Lightmode"
+      >
+        <svg class="icon">
+          <use xlink:href="#icon-theme" />
+        </svg>
+      </a>
+      <a
+        href="#"
+        id="notification"
+        class="icon-button"
+        title="Enable Notifications"
+        hidden
+      >
+        <svg class="icon">
+          <use xlink:href="#notifications" />
+        </svg>
+      </a>
+      <a
+        href="#"
+        id="install"
+        class="icon-button"
+        title="Install Snapdrop"
+        hidden
+      >
+        <svg class="icon">
+          <use xlink:href="#homescreen" />
+        </svg>
+      </a>
     </header>
     <!-- Peers -->
     <x-peers class="center"></x-peers>
     <x-no-peers>
-        <h2>Open Snapdrop on other devices to send files</h2>
+      <h2>Open Snapdrop on other devices to send files</h2>
     </x-no-peers>
-    <x-instructions desktop="Click to send files or right click to send a message" mobile="Tap to send files or long tap to send a message"></x-instructions>
+    <x-instructions
+      desktop="Click to send files or right click to send a message"
+      mobile="Tap to send files or long tap to send a message"
+    ></x-instructions>
     <!-- Footer -->
     <footer class="column">
-        <svg class="icon logo">
-            <use xlink:href="#wifi-tethering" />
-        </svg>
-        <div id="displayName" placeholder="The easiest way to transfer data across devices"></div>
-        <div class="font-body2">You can be discovered by everyone on this network</div>
+      <svg class="icon logo">
+        <use xlink:href="#wifi-tethering" />
+      </svg>
+      <div
+        id="displayName"
+        placeholder="The easiest way to transfer data across devices"
+      ></div>
+      <div class="font-body2">
+        You can be discovered by everyone on this network
+      </div>
     </footer>
     <!-- Receive Dialog -->
     <x-dialog id="receiveDialog">
-        <x-background class="full center">
-            <x-paper shadow="2">
-                <h3>File Received</h3>
-                <div class="font-subheading" id="fileName">Filename</div>
-                <div class="font-body2" id="fileSize"></div>
-                <div class='preview' style="visibility: hidden;">
-                    <img id='img-preview' src="">
-                </div>
-                <div class="row">
-                    <label for="autoDownload" class="grow">Ask to save each file before downloading</label>
-                    <input type="checkbox" id="autoDownload" checked="">
-                </div>
-                <div class="row-reverse">
-                    <a class="button" close id="download" title="Download File" autofocus>Save</a>
-                    <button class="button" close>Ignore</button>
-                </div>
-            </x-paper>
-        </x-background>
+      <x-background class="full center">
+        <x-paper shadow="2">
+          <h3>File Received</h3>
+          <div class="font-subheading" id="fileName">Filename</div>
+          <div class="font-body2" id="fileSize"></div>
+          <div class="preview" style="visibility: hidden">
+            <img id="img-preview" src="" />
+          </div>
+          <div class="row">
+            <label for="autoDownload" class="grow"
+              >Ask to save each file before downloading</label
+            >
+            <input type="checkbox" id="autoDownload" checked="" />
+          </div>
+          <div class="row-reverse">
+            <a
+              class="button"
+              close
+              id="download"
+              title="Download File"
+              autofocus
+              >Save</a
+            >
+            <button class="button" close>Ignore</button>
+          </div>
+        </x-paper>
+      </x-background>
     </x-dialog>
     <!-- Send Text Dialog -->
     <x-dialog id="sendTextDialog">
-        <form action="#">
-            <x-background class="full center">
-                <x-paper shadow="2">
-                    <h3>Send a Message</h3>
-                    <div id="textInput" class="textarea" role="textbox" placeholder="Send a message" autocomplete="off" autofocus contenteditable></div>
-                    <div class="row-reverse">
-                        <button class="button" type="submit" close>Send</button>
-                        <a class="button" close>Cancel</a>
-                    </div>
-                </x-paper>
-            </x-background>
-        </form>
+      <form action="#">
+        <x-background class="full center">
+          <x-paper shadow="2">
+            <h3>Send a Message</h3>
+            <div
+              id="textInput"
+              class="textarea"
+              role="textbox"
+              placeholder="Send a message"
+              autocomplete="off"
+              autofocus
+              contenteditable
+            ></div>
+            <div class="row-reverse">
+              <button class="button" type="submit" close>Send</button>
+              <a class="button" close>Cancel</a>
+            </div>
+          </x-paper>
+        </x-background>
+      </form>
     </x-dialog>
     <!-- Receive Text Dialog -->
     <x-dialog id="receiveTextDialog">
-        <x-background class="full center">
-            <x-paper shadow="2">
-                <h3>Message Received</h3>
-                <div class="font-subheading" id="text"></div>
-                <div class="row-reverse">
-                    <button class="button" id="copy" close autofocus>Copy</button>
-                    <button class="button" close>Close</button>
-                </div>
-            </x-paper>
-        </x-background>
+      <x-background class="full center">
+        <x-paper shadow="2">
+          <h3>Message Received</h3>
+          <div class="font-subheading" id="text"></div>
+          <div class="row-reverse">
+            <button class="button" id="copy" close autofocus>Copy</button>
+            <button class="button" close>Close</button>
+          </div>
+        </x-paper>
+      </x-background>
     </x-dialog>
     <!-- Toast -->
     <div class="toast-container full center">
-        <x-toast class="row" shadow="1" id="toast">File Transfer Completed</x-toast>
+      <x-toast class="row" shadow="1" id="toast"
+        >File Transfer Completed</x-toast
+      >
     </div>
     <!-- About Page -->
     <x-about id="about" class="full center column">
-        <section class="center column fade-in">
-            <header class="row-reverse">
-                <a href="#" class="close icon-button">
-                    <svg class="icon">
-                        <use xlink:href="#close" />
-                    </svg>
-                </a>
-            </header>
-            <svg class="icon logo">
-                <use xlink:href="#wifi-tethering" />
+      <section class="center column fade-in">
+        <header class="row-reverse">
+          <a href="#" class="close icon-button">
+            <svg class="icon">
+              <use xlink:href="#close" />
             </svg>
-            <h1>Snapdrop</h1>
-            <div class="font-subheading">The easiest way to transfer files across devices</div>
-            <div class="row">
-                <a class="icon-button" target="_blank" href="https://github.com/RobinLinus/snapdrop" title="Snapdrop on Github" rel="noreferrer">
-                    <svg class="icon">
-                        <use xlink:href="#github" />
-                    </svg>
-                </a>
-                <a class="icon-button" target="_blank" href="https://www.paypal.com/donate?hosted_button_id=FTP9DXUR7LA7Q" title="Help cover the server costs!" rel="noreferrer">
-                    <svg class="icon">
-                        <use xlink:href="#monetarization" />
-                    </svg>
-                </a>
-                <a class="icon-button" target="_blank" href="https://twitter.com/intent/tweet?text=https://snapdrop.net%20by%20@robin_linus%20&" title="Tweet about Snapdrop" rel="noreferrer">
-                    <svg class="icon">
-                        <use xlink:href="#twitter" />
-                    </svg>
-                </a>
-                <a class="icon-button" target="_blank" href="https://github.com/RobinLinus/snapdrop/blob/master/docs/faq.md" title="Frequently asked questions" rel="noreferrer">
-                    <svg class="icon">
-                        <use xlink:href="#help-outline" />
-                    </svg>
-                </a>
-            </div>
-        </section>
-        <x-background></x-background>
+          </a>
+        </header>
+        <svg class="icon logo">
+          <use xlink:href="#wifi-tethering" />
+        </svg>
+        <h1>Snapdrop</h1>
+        <div class="font-subheading">
+          The easiest way to transfer files across devices
+        </div>
+        <div class="row">
+          <a
+            class="icon-button"
+            target="_blank"
+            href="https://github.com/RobinLinus/snapdrop"
+            title="Snapdrop on Github"
+            rel="noreferrer"
+          >
+            <svg class="icon">
+              <use xlink:href="#github" />
+            </svg>
+          </a>
+          <a
+            class="icon-button"
+            target="_blank"
+            href="https://www.paypal.com/donate?hosted_button_id=FTP9DXUR7LA7Q"
+            title="Help cover the server costs!"
+            rel="noreferrer"
+          >
+            <svg class="icon">
+              <use xlink:href="#monetarization" />
+            </svg>
+          </a>
+          <a
+            class="icon-button"
+            target="_blank"
+            href="https://twitter.com/intent/tweet?text=https://snapdrop.net%20by%20@robin_linus%20&"
+            title="Tweet about Snapdrop"
+            rel="noreferrer"
+          >
+            <svg class="icon">
+              <use xlink:href="#twitter" />
+            </svg>
+          </a>
+          <a
+            class="icon-button"
+            target="_blank"
+            href="https://github.com/RobinLinus/snapdrop/blob/master/docs/faq.md"
+            title="Frequently asked questions"
+            rel="noreferrer"
+          >
+            <svg class="icon">
+              <use xlink:href="#help-outline" />
+            </svg>
+          </a>
+        </div>
+      </section>
+      <x-background></x-background>
     </x-about>
     <!-- SVG Icon Library -->
-    <svg style="display: none;">
-        <symbol id=wifi-tethering viewBox="0 0 24 24">
-            <path d="M12 11c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 2c0-3.31-2.69-6-6-6s-6 2.69-6 6c0 2.22 1.21 4.15 3 5.19l1-1.74c-1.19-.7-2-1.97-2-3.45 0-2.21 1.79-4 4-4s4 1.79 4 4c0 1.48-.81 2.75-2 3.45l1 1.74c1.79-1.04 3-2.97 3-5.19zM12 3C6.48 3 2 7.48 2 13c0 3.7 2.01 6.92 4.99 8.65l1-1.73C5.61 18.53 4 15.96 4 13c0-4.42 3.58-8 8-8s8 3.58 8 8c0 2.96-1.61 5.53-4 6.92l1 1.73c2.99-1.73 5-4.95 5-8.65 0-5.52-4.48-10-10-10z"></path>
-        </symbol>
-        <symbol id=desktop-mac viewBox="0 0 24 24">
-            <path d="M21 2H3c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h7l-2 3v1h8v-1l-2-3h7c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 12H3V4h18v10z"></path>
-        </symbol>
-        <symbol id=phone-iphone viewBox="0 0 24 24">
-            <path d="M15.5 1h-8C6.12 1 5 2.12 5 3.5v17C5 21.88 6.12 23 7.5 23h8c1.38 0 2.5-1.12 2.5-2.5v-17C18 2.12 16.88 1 15.5 1zm-4 21c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm4.5-4H7V4h9v14z"></path>
-        </symbol>
-        <symbol id=tablet-mac viewBox="0 0 24 24">
-            <path d="M18.5 0h-14C3.12 0 2 1.12 2 2.5v19C2 22.88 3.12 24 4.5 24h14c1.38 0 2.5-1.12 2.5-2.5v-19C21 1.12 19.88 0 18.5 0zm-7 23c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm7.5-4H4V3h15v16z"></path>
-        </symbol>
-        <symbol id=info-outline viewBox="0 0 24 24">
-            <path d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"></path>
-        </symbol>
-        <symbol id=close viewBox="0 0 24 24">
-            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-        </symbol>
-        <symbol id=help-outline viewBox="0 0 24 24">
-            <path d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"></path>
-        </symbol>
-        <symbol id="twitter">
-            <path d="M23.954 4.569c-.885.389-1.83.654-2.825.775 1.014-.611 1.794-1.574 2.163-2.723-.951.555-2.005.959-3.127 1.184-.896-.959-2.173-1.559-3.591-1.559-2.717 0-4.92 2.203-4.92 4.917 0 .39.045.765.127 1.124C7.691 8.094 4.066 6.13 1.64 3.161c-.427.722-.666 1.561-.666 2.475 0 1.71.87 3.213 2.188 4.096-.807-.026-1.566-.248-2.228-.616v.061c0 2.385 1.693 4.374 3.946 4.827-.413.111-.849.171-1.296.171-.314 0-.615-.03-.916-.086.631 1.953 2.445 3.377 4.604 3.417-1.68 1.319-3.809 2.105-6.102 2.105-.39 0-.779-.023-1.17-.067 2.189 1.394 4.768 2.209 7.557 2.209 9.054 0 13.999-7.496 13.999-13.986 0-.209 0-.42-.015-.63.961-.689 1.8-1.56 2.46-2.548l-.047-.02z" />
-        </symbol>
-        <symbol id="github">
-            <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
-        </symbol>
-        <g id="notifications">
-            <path d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.89 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z" />
-        </g>
-        <symbol id="homescreen">
-            <path fill="none" d="M0 0h24v24H0V0z" />
-            <path d="M18 1.01L8 1c-1.1 0-2 .9-2 2v3h2V5h10v14H8v-1H6v3c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM10 15h2V8H5v2h3.59L3 15.59 4.41 17 10 11.41z" />
-            <path fill="none" d="M0 0h24v24H0V0z" />
-        </symbol>
-        <symbol id="monetarization">
-            <path d="M0 0h24v24H0z" fill="none" />
-            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1.41 16.09V20h-2.67v-1.93c-1.71-.36-3.16-1.46-3.27-3.4h1.96c.1 1.05.82 1.87 2.65 1.87 1.96 0 2.4-.98 2.4-1.59 0-.83-.44-1.61-2.67-2.14-2.48-.6-4.18-1.62-4.18-3.67 0-1.72 1.39-2.84 3.11-3.21V4h2.67v1.95c1.86.45 2.79 1.86 2.85 3.39H14.3c-.05-1.11-.64-1.87-2.22-1.87-1.5 0-2.4.68-2.4 1.64 0 .84.65 1.39 2.67 1.91s4.18 1.39 4.18 3.91c-.01 1.83-1.38 2.83-3.12 3.16z" />
-        </symbol>
-        <symbol id="icon-theme" viewBox="0 0 24 24">
-         <rect fill="none" height="24" width="24"/><path d="M12,3c-4.97,0-9,4.03-9,9s4.03,9,9,9s9-4.03,9-9c0-0.46-0.04-0.92-0.1-1.36c-0.98,1.37-2.58,2.26-4.4,2.26 c-2.98,0-5.4-2.42-5.4-5.4c0-1.81,0.89-3.42,2.26-4.4C12.92,3.04,12.46,3,12,3L12,3z"/>
-        </symbol>
+    <svg style="display: none">
+      <symbol id="wifi-tethering" viewBox="0 0 24 24">
+        <path
+          d="M12 11c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 2c0-3.31-2.69-6-6-6s-6 2.69-6 6c0 2.22 1.21 4.15 3 5.19l1-1.74c-1.19-.7-2-1.97-2-3.45 0-2.21 1.79-4 4-4s4 1.79 4 4c0 1.48-.81 2.75-2 3.45l1 1.74c1.79-1.04 3-2.97 3-5.19zM12 3C6.48 3 2 7.48 2 13c0 3.7 2.01 6.92 4.99 8.65l1-1.73C5.61 18.53 4 15.96 4 13c0-4.42 3.58-8 8-8s8 3.58 8 8c0 2.96-1.61 5.53-4 6.92l1 1.73c2.99-1.73 5-4.95 5-8.65 0-5.52-4.48-10-10-10z"
+        ></path>
+      </symbol>
+      <symbol id="desktop-mac" viewBox="0 0 24 24">
+        <path
+          d="M21 2H3c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h7l-2 3v1h8v-1l-2-3h7c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 12H3V4h18v10z"
+        ></path>
+      </symbol>
+      <symbol id="phone-iphone" viewBox="0 0 24 24">
+        <path
+          d="M15.5 1h-8C6.12 1 5 2.12 5 3.5v17C5 21.88 6.12 23 7.5 23h8c1.38 0 2.5-1.12 2.5-2.5v-17C18 2.12 16.88 1 15.5 1zm-4 21c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm4.5-4H7V4h9v14z"
+        ></path>
+      </symbol>
+      <symbol id="tablet-mac" viewBox="0 0 24 24">
+        <path
+          d="M18.5 0h-14C3.12 0 2 1.12 2 2.5v19C2 22.88 3.12 24 4.5 24h14c1.38 0 2.5-1.12 2.5-2.5v-19C21 1.12 19.88 0 18.5 0zm-7 23c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5 1.5.67 1.5 1.5-.67 1.5-1.5 1.5zm7.5-4H4V3h15v16z"
+        ></path>
+      </symbol>
+      <symbol id="info-outline" viewBox="0 0 24 24">
+        <path
+          d="M11 17h2v-6h-2v6zm1-15C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zM11 9h2V7h-2v2z"
+        ></path>
+      </symbol>
+      <symbol id="close" viewBox="0 0 24 24">
+        <path
+          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        ></path>
+      </symbol>
+      <symbol id="help-outline" viewBox="0 0 24 24">
+        <path
+          d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z"
+        ></path>
+      </symbol>
+      <symbol id="twitter">
+        <path
+          d="M23.954 4.569c-.885.389-1.83.654-2.825.775 1.014-.611 1.794-1.574 2.163-2.723-.951.555-2.005.959-3.127 1.184-.896-.959-2.173-1.559-3.591-1.559-2.717 0-4.92 2.203-4.92 4.917 0 .39.045.765.127 1.124C7.691 8.094 4.066 6.13 1.64 3.161c-.427.722-.666 1.561-.666 2.475 0 1.71.87 3.213 2.188 4.096-.807-.026-1.566-.248-2.228-.616v.061c0 2.385 1.693 4.374 3.946 4.827-.413.111-.849.171-1.296.171-.314 0-.615-.03-.916-.086.631 1.953 2.445 3.377 4.604 3.417-1.68 1.319-3.809 2.105-6.102 2.105-.39 0-.779-.023-1.17-.067 2.189 1.394 4.768 2.209 7.557 2.209 9.054 0 13.999-7.496 13.999-13.986 0-.209 0-.42-.015-.63.961-.689 1.8-1.56 2.46-2.548l-.047-.02z"
+        />
+      </symbol>
+      <symbol id="github">
+        <path
+          d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+        />
+      </symbol>
+      <g id="notifications">
+        <path
+          d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.89 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
+        />
+      </g>
+      <symbol id="homescreen">
+        <path fill="none" d="M0 0h24v24H0V0z" />
+        <path
+          d="M18 1.01L8 1c-1.1 0-2 .9-2 2v3h2V5h10v14H8v-1H6v3c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM10 15h2V8H5v2h3.59L3 15.59 4.41 17 10 11.41z"
+        />
+        <path fill="none" d="M0 0h24v24H0V0z" />
+      </symbol>
+      <symbol id="monetarization">
+        <path d="M0 0h24v24H0z" fill="none" />
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1.41 16.09V20h-2.67v-1.93c-1.71-.36-3.16-1.46-3.27-3.4h1.96c.1 1.05.82 1.87 2.65 1.87 1.96 0 2.4-.98 2.4-1.59 0-.83-.44-1.61-2.67-2.14-2.48-.6-4.18-1.62-4.18-3.67 0-1.72 1.39-2.84 3.11-3.21V4h2.67v1.95c1.86.45 2.79 1.86 2.85 3.39H14.3c-.05-1.11-.64-1.87-2.22-1.87-1.5 0-2.4.68-2.4 1.64 0 .84.65 1.39 2.67 1.91s4.18 1.39 4.18 3.91c-.01 1.83-1.38 2.83-3.12 3.16z"
+        />
+      </symbol>
+      <symbol id="icon-theme" viewBox="0 0 24 24">
+        <rect fill="none" height="24" width="24" />
+        <path
+          d="M12,3c-4.97,0-9,4.03-9,9s4.03,9,9,9s9-4.03,9-9c0-0.46-0.04-0.92-0.1-1.36c-0.98,1.37-2.58,2.26-4.4,2.26 c-2.98,0-5.4-2.42-5.4-5.4c0-1.81,0.89-3.42,2.26-4.4C12.92,3.04,12.46,3,12,3L12,3z"
+        />
+      </symbol>
     </svg>
     <!-- Scripts -->
     <script src="scripts/network.js"></script>
@@ -218,25 +336,26 @@
     <script src="scripts/clipboard.js" async></script>
     <!-- Sounds -->
     <audio id="blop" autobuffer="true">
-        <source src="/sounds/blop.mp3" type="audio/mpeg">
-        <source src="/sounds/blop.ogg" type="audio/ogg">
+      <source src="/sounds/blop.mp3" type="audio/mpeg" />
+      <source src="/sounds/blop.ogg" type="audio/ogg" />
     </audio>
     <!-- no script -->
     <noscript>
-        <x-noscript class="full center column">
-            <h1>Enable JavaScript</h1>
-            <h3>Snapdrop works only with JavaScript</h3>
-        </x-noscript>
-        <style>
+      <x-noscript class="full center column">
+        <h1>Enable JavaScript</h1>
+        <h3>Snapdrop works only with JavaScript</h3>
+      </x-noscript>
+      <style>
         x-noscript {
-            background: #599cfc;
-            color: white;
-            z-index: 2;
+          background: #599cfc;
+          color: white;
+          z-index: 2;
         }
 
         a[href="#info"] {
-            color: white;
+          color: white;
         }
-        </style>
+      </style>
     </noscript>
-</body>
+  </body>
+</html>

--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -186,8 +186,8 @@ class Peer {
     }
 
     _onChunkReceived(chunk) {
-        if(!chunk.byteLength) return;
-        
+        if (!chunk.byteLength) return;
+
         this._digester.unchunk(chunk);
         const progress = this._digester.progress;
         this._onDownloadProgress(progress);
@@ -254,7 +254,7 @@ class RTCPeer extends Peer {
     }
 
     _openChannel() {
-        const channel = this._conn.createDataChannel('data-channel', { 
+        const channel = this._conn.createDataChannel('data-channel', {
             ordered: true,
             reliable: true // Obsolete. See https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/reliable
         });
@@ -280,7 +280,7 @@ class RTCPeer extends Peer {
 
         if (message.sdp) {
             this._conn.setRemoteDescription(new RTCSessionDescription(message.sdp))
-                .then( _ => {
+                .then(_ => {
                     if (message.sdp.type === 'offer') {
                         return this._conn.createAnswer()
                             .then(d => this._onDescription(d));

--- a/client/scripts/theme.js
+++ b/client/scripts/theme.js
@@ -1,24 +1,24 @@
-(function(){
-  
+(function () {
+
   // Select the button
   const btnTheme = document.getElementById('theme');
   // Check for dark mode preference at the OS level
   const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-   
+
   // Get the user's theme preference from local storage, if it's available
   const currentTheme = localStorage.getItem('theme');
   // If the user's preference in localStorage is dark...
   if (currentTheme == 'dark') {
     // ...let's toggle the .dark-theme class on the body
     document.body.classList.toggle('dark-theme');
-  // Otherwise, if the user's preference in localStorage is light...
+    // Otherwise, if the user's preference in localStorage is light...
   } else if (currentTheme == 'light') {
     // ...let's toggle the .light-theme class on the body
     document.body.classList.toggle('light-theme');
   }
-   
+
   // Listen for a click on the button 
-  btnTheme.addEventListener('click', function() {
+  btnTheme.addEventListener('click', function () {
     // If the user's OS setting is dark and matches our .dark-theme class...
     if (prefersDarkScheme.matches) {
       // ...then toggle the light mode class

--- a/client/scripts/ui.js
+++ b/client/scripts/ui.js
@@ -262,11 +262,11 @@ class ReceiveDialog extends Dialog {
         $a.href = url;
         $a.download = file.name;
 
-        if(this._autoDownload()){
+        if (this._autoDownload()) {
             $a.click()
             return
         }
-        if(file.mime.split('/')[0] === 'image'){
+        if (file.mime.split('/')[0] === 'image') {
             console.log('the file is image');
             this.$el.querySelector('.preview').style.visibility = 'inherit';
             this.$el.querySelector("#img-preview").src = url;
@@ -304,7 +304,7 @@ class ReceiveDialog extends Dialog {
     }
 
 
-    _autoDownload(){
+    _autoDownload() {
         return !this.$el.querySelector('#autoDownload').checked
     }
 }
@@ -435,12 +435,12 @@ class Notifications {
         }
 
         // Notification is persistent on Android. We have to close it manually
-        const visibilitychangeHandler = () => {                             
-            if (document.visibilityState === 'visible') {    
+        const visibilitychangeHandler = () => {
+            if (document.visibilityState === 'visible') {
                 notification.close();
                 Events.off('visibilitychange', visibilitychangeHandler);
-            }                                                       
-        };                                                                                
+            }
+        };
         Events.on('visibilitychange', visibilitychangeHandler);
 
         return notification;
@@ -516,7 +516,7 @@ class WebShareTargetUI {
         let shareTargetText = title ? title : '';
         shareTargetText += text ? shareTargetText ? ' ' + text : text : '';
 
-        if(url) shareTargetText = url; // We share only the Link - no text. Because link-only text becomes clickable.
+        if (url) shareTargetText = url; // We share only the Link - no text. Because link-only text becomes clickable.
 
         if (!shareTargetText) return;
         window.shareTargetText = shareTargetText;
@@ -617,13 +617,13 @@ Events.on('load', () => {
 
     function animate() {
         if (loading || step % dw < dw - 5) {
-            requestAnimationFrame(function() {
+            requestAnimationFrame(function () {
                 drawCircles();
                 animate();
             });
         }
     }
-    window.animateBackground = function(l) {
+    window.animateBackground = function (l) {
         loading = l;
         animate();
     };

--- a/client/service-worker.js
+++ b/client/service-worker.js
@@ -11,11 +11,11 @@ var urlsToCache = [
   'images/favicon-96x96.png'
 ];
 
-self.addEventListener('install', function(event) {
+self.addEventListener('install', function (event) {
   // Perform install steps
   event.waitUntil(
     caches.open(CACHE_NAME)
-      .then(function(cache) {
+      .then(function (cache) {
         console.log('Opened cache');
         return cache.addAll(urlsToCache);
       })
@@ -23,32 +23,32 @@ self.addEventListener('install', function(event) {
 });
 
 
-self.addEventListener('fetch', function(event) {
+self.addEventListener('fetch', function (event) {
   event.respondWith(
     caches.match(event.request)
-      .then(function(response) {
+      .then(function (response) {
         // Cache hit - return response
         if (response) {
           return response;
         }
         return fetch(event.request);
       }
-    )
+      )
   );
 });
 
 
-self.addEventListener('activate', function(event) {
+self.addEventListener('activate', function (event) {
   console.log('Updating Service Worker...')
   event.waitUntil(
-    caches.keys().then(function(cacheNames) {
+    caches.keys().then(function (cacheNames) {
       return Promise.all(
-        cacheNames.filter(function(cacheName) {
+        cacheNames.filter(function (cacheName) {
           // Return true if you want to remove this cache,
           // but remember that caches are shared across
           // the whole origin
           return true
-        }).map(function(cacheName) {
+        }).map(function (cacheName) {
           return caches.delete(cacheName);
         })
       );

--- a/client/styles.css
+++ b/client/styles.css
@@ -674,7 +674,7 @@ screen and (min-width: 1100px) {
 */
 @supports (-webkit-overflow-scrolling: touch) {
 
-    
+
     html {
         position: fixed;
     }
@@ -717,8 +717,9 @@ x-dialog x-paper {
     color: var(--text-color);
     background-color: var(--bg-color-secondary);
 }
+
 /* Image Preview */
-#img-preview{
+#img-preview {
     max-height: 50vh;
     margin: auto;
     display: block;
@@ -754,4 +755,3 @@ x-dialog x-paper {
         overflow: hidden;
     }
 }
-

--- a/server/index.js
+++ b/server/index.js
@@ -1,14 +1,14 @@
 var process = require('process')
 // Handle SIGINT
 process.on('SIGINT', () => {
-  console.info("SIGINT Received, exiting...")
-  process.exit(0)
+    console.info("SIGINT Received, exiting...")
+    process.exit(0)
 })
 
 // Handle SIGTERM
 process.on('SIGTERM', () => {
-  console.info("SIGTERM Received, exiting...")
-  process.exit(0)
+    console.info("SIGTERM Received, exiting...")
+    process.exit(0)
 })
 
 const parser = require('ua-parser-js');
@@ -210,18 +210,18 @@ class Peer {
 
 
         let deviceName = '';
-        
+
         if (ua.os && ua.os.name) {
             deviceName = ua.os.name.replace('Mac OS', 'Mac') + ' ';
         }
-        
+
         if (ua.device.model) {
             deviceName += ua.device.model;
         } else {
             deviceName += ua.browser.name;
         }
 
-        if(!deviceName)
+        if (!deviceName)
             deviceName = 'Unknown Device';
 
         const displayName = uniqueNamesGenerator({
@@ -278,15 +278,15 @@ class Peer {
 }
 
 Object.defineProperty(String.prototype, 'hashCode', {
-  value: function() {
-    var hash = 0, i, chr;
-    for (i = 0; i < this.length; i++) {
-      chr   = this.charCodeAt(i);
-      hash  = ((hash << 5) - hash) + chr;
-      hash |= 0; // Convert to 32bit integer
+    value: function () {
+        var hash = 0, i, chr;
+        for (i = 0; i < this.length; i++) {
+            chr = this.charCodeAt(i);
+            hash = ((hash << 5) - hash) + chr;
+            hash |= 0; // Convert to 32bit integer
+        }
+        return hash;
     }
-    return hash;
-  }
 });
 
 const server = new SnapdropServer(process.env.PORT || 3000);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,8 +1,56 @@
 {
   "name": "snapdrop",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "snapdrop",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "ua-parser-js": "^0.7.24",
+        "unique-names-generator": "^4.3.0",
+        "ws": "^7.4.6"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+      "integrity": "sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/unique-names-generator": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/unique-names-generator/-/unique-names-generator-4.3.0.tgz",
+      "integrity": "sha512-uNX6jVFjBXfZtsc7B8jVPJ3QdfCF/Sjde4gxsy3rNQmHuWGFarnU7IFGdxZKJ4h4uRjANQc6rG7GiGolRW9fgA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  },
   "dependencies": {
     "ua-parser-js": {
       "version": "0.7.24",
@@ -17,7 +65,8 @@
     "ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "requires": {}
     }
   }
 }


### PR DESCRIPTION
Formatted all JS, CSS and HTML code.
Also updated server lockfile version (package-lock.json) from 1 to 2.

---

This pull won't introduce any change, but just uniformate code to the same formatting.

Lockfile version update made through NPM install command, which auto-updated it to respect the new NPM lockfile standard (starting from NPM v7) (more info [here](https://github.com/RobinLinus/snapdrop.git)).

---

cc. @RobinLinus 