### PR TITLE
fix error: Failed to execute 'readAsArrayBuffer' on 'FileReader': The…

### DIFF
--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -448,7 +448,8 @@ class FileChunker {
         this._offset += chunk.byteLength;
         this._partitionSize += chunk.byteLength;
         this._onChunk(chunk);
-        if (this._isPartitionEnd() || this.isFileEnd()) {
+        if (this.isFileEnd()) return;
+        if (this._isPartitionEnd()) {
             this._onPartitionEnd(this._offset);
             return;
         }


### PR DESCRIPTION
Fix error:  Failed to execute 'readAsArrayBuffer' on 'FileReader': The object is already busy reading Blobs

Error explanation:

1. When a file is ended `FileChunker` sends `"chunk"` and then sends `"partition"`.
2. The receiver process `"chunk"` first, when a file is ended `FileDigister` send `"transfer-complete"`.
3. The sender fire ` _dequeueFile` which make a new chunker with a new file.
4. Then the receiver process ` "partition" ` of the previous file and then send `"partition-received"` (which is not valid at that point & causes the error).
5. The sender will receive `"partition-received"` , which will fire `_sendNextPartition`.
6. `FileReader`  will be busy reading the new file, then it will throw an error.