### PR TITLE
Should not show self in the peers list

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -86,6 +86,7 @@ class SnapdropServer {
 
         // notify all other peers
         for (const otherPeerId in this._rooms[peer.ip]) {
+            if (otherPeerId === peer.id) continue;
             const otherPeer = this._rooms[peer.ip][otherPeerId];
             this._send(otherPeer, {
                 type: 'peer-joined',
@@ -96,6 +97,7 @@ class SnapdropServer {
         // notify peer about the other peers
         const otherPeers = [];
         for (const otherPeerId in this._rooms[peer.ip]) {
+            if (otherPeerId === peer.id) continue;
             otherPeers.push(this._rooms[peer.ip][otherPeerId].getInfo());
         }
 


### PR DESCRIPTION
This is a possible fix to this issue: https://github.com/RobinLinus/snapdrop/issues/526

I have found out these steps to reproduce, on MAC safari:
- Launch https://snapdrop.net/. Now the peers list is empty.
- Turn off WIFI connection, turn on WIFI again.
- Peers list may show the peer itself
<img width="463" alt="Screen Shot 2022-11-05 at 1 05 23 AM" src="https://user-images.githubusercontent.com/2494919/200034375-afc7ed62-7331-4375-ab23-340e6b2ce406.png">
