### PR TITLE
fix this._isCaller variable typo

### DIFF
--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -302,7 +302,7 @@ class RTCPeer extends Peer {
 
     _onChannelClosed() {
         console.log('RTC: channel closed', this._peerId);
-        if (!this.isCaller) return;
+        if (!this._isCaller) return;
         this._connect(this._peerId, true); // reopen the channel
     }
 


### PR DESCRIPTION
there is a type in network.js that prevents the application to reopen a channel that is closed.

Should increase stability after errors