### PR TITLE
[stability] Only Show New Peer On Open Channel

### DIFF
--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -293,6 +293,7 @@ class RTCPeer extends Peer {
 
     _onChannelOpened(event) {
         console.log('RTC: channel opened with', this._peerId);
+        Events.fire('peer-connected', this._peerId);
         const channel = event.channel || event.target;
         channel.binaryType = 'arraybuffer';
         channel.onmessage = e => this._onMessage(e.data);
@@ -302,7 +303,8 @@ class RTCPeer extends Peer {
 
     _onChannelClosed() {
         console.log('RTC: channel closed', this._peerId);
-        if (!this.isCaller) return;
+        Events.fire('peer-left', this._peerId);
+        if (!this._isCaller) return;
         this._connect(this._peerId, true); // reopen the channel
     }
 

--- a/client/scripts/ui.js
+++ b/client/scripts/ui.js
@@ -26,8 +26,6 @@ class PeersUI {
     _onPeerJoined(peer) {
         if ($(peer.id)) return; // peer already exists
         const peerUI = new PeerUI(peer);
-        $$('x-peers').appendChild(peerUI.$el);
-        setTimeout(e => window.animateBackground(false), 1750); // Stop animation
     }
 
     _onPeers(peers) {
@@ -91,8 +89,18 @@ class PeerUI {
 
     constructor(peer) {
         this._peer = peer;
-        this._initDom();
-        this._bindListeners(this.$el);
+        this.callbackFunction = (e) => this._onPeerConnected(e.detail);
+        Events.on('peer-connected', this.callbackFunction);
+    }
+
+    _onPeerConnected(peerId) {
+        if (peerId === this._peer.id) {
+            Events.off('peer-connected', this.callbackFunction)
+            this._initDom();
+            this._bindListeners(this.$el);
+            $$('x-peers').appendChild(this.$el);
+            setTimeout(e => window.animateBackground(false), 1750); // Stop animation
+        }
     }
 
     _initDom() {


### PR DESCRIPTION
Sometimes Peers are shown correctly in the UI but somehow the peer to peer channel cannot be established. Therefor, sending to peers fails as there is no open channel.

This PR puts the creation of new peers to after the channel is opened and removes it when the channel is closed again.
That way, only peers with an open channel are shown. Should improve stability.

This also includes #531 