### PR TITLE
Check for CF-Connecting-IP and decreased timeout

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -137,7 +137,7 @@ class SnapdropServer {
 
     _keepAlive(peer) {
         this._cancelKeepAlive(peer);
-        var timeout = 30000;
+        var timeout = 500;
         if (!peer.lastBeat) {
             peer.lastBeat = Date.now();
         }
@@ -182,7 +182,9 @@ class Peer {
     }
 
     _setIP(request) {
-        if (request.headers['x-forwarded-for']) {
+        if (request.headers['cf-connecting-ip']) {
+            this.ip = request.headers['cf-connecting-ip'].split(/\s*,\s*/)[0];
+        } else if (request.headers['x-forwarded-for']) {
             this.ip = request.headers['x-forwarded-for'].split(/\s*,\s*/)[0];
         } else {
             this.ip = request.connection.remoteAddress;


### PR DESCRIPTION
When hosting Snapdrop behind Cloudflare, `X-Forwarded-For` is useless. Furthermore, I'm hosting my installation behind another internal proxy, so, in the end, `X-Forwarder-For` is set to the internal proxy's IP for all the peer, which can see each other regardless being on different networks. To fix this I made `_setIP` check if the header "cf-connecting-ip" exists, then sets the IP accordingly.

Lastly, when a peer changes network (e.g. a phone switches from wifi to mobile data), the function `_leaveRoom` is not called and the peer stays visible to others connected to the same room for a whole minute: I adjusted the timeout to what I think is a more reasonable value (500ms, so `_leaveRoom` is called after 1s).