### PR TITLE
[stability] add "restart: always" to docker-compose service configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./server/:/home/node/app
     command: ash -c "npm i && node index.js"
+    restart: always
   nginx:
     build:
       context: ./docker/
@@ -23,3 +24,4 @@ services:
     env_file: ./docker/fqdn.env
     entrypoint: /mnt/openssl/create.sh
     command: ["nginx", "-g", "daemon off;"]
+    restart: always


### PR DESCRIPTION
Simple auto restart to prevent the server from crashing permanently everytime an error is thrown.

@RobinLinus I would really like to help increase snapdrops stabilty but I'd need to see some logs for that. Does snapdrop.net use the docker or is node and nginx installed seperately?

Also there are now several PR on stability:
- #537 
- #531 
- #458 