### PR TITLE
[stability] fix socket closing when peer leaves

### DIFF
--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -407,8 +407,8 @@ class PeersManager {
     _onPeerLeft(peerId) {
         const peer = this.peers[peerId];
         delete this.peers[peerId];
-        if (!peer || !peer._peer) return;
-        peer._peer.close();
+        if (!peer || !peer._conn) return;
+        peer._conn.close();
     }
 
 }


### PR DESCRIPTION
## Error
Often the following error is logged:
```
Failed to execute 'setLocalDescription' on 'RTCPeerConnection': Failed to set local answer sdp: Called in wrong state: stable
```
(See: #542 #345 #258 #252 #249 #247 #233 #194)

## Cause
I discovered that sockets are not properly closed when a peer leaves and quickly rejoines

## Fix
This PR fixes the closing of sockets:
- In the method `_onPeerLeft(peerId)` the property `peer._peer` must be `peer._conn`.

Additionally this PR closes all p2p connections when the websocket connection is closed.


## Stability
Together with #537 and #531 this increases the stabilty a lot on my instance
