### PR TITLE
fix typo on repeatPartition()

### DIFF
--- a/client/scripts/network.js
+++ b/client/scripts/network.js
@@ -458,7 +458,7 @@ class FileChunker {
 
     repeatPartition() {
         this._offset -= this._partitionSize;
-        this._nextPartition();
+        this.nextPartition();
     }
 
     _isPartitionEnd() {


### PR DESCRIPTION
fixes small typo on method calling

Not really relevant as method `repeatPartition()` is currently never used