### PR TITLE
[bug] fix image overflow

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -719,6 +719,7 @@ x-dialog x-paper {
 }
 /* Image Preview */
 #img-preview{
+    max-width: 100%;
     max-height: 50vh;
     margin: auto;
     display: block;


### PR DESCRIPTION
Depending on the image the preview is bigger that the containing ReceiveDialog. This PR fixes this.
Successor of #539 

Before:
![Bildschirmfoto am 2023-01-06 um 18 12 01](https://user-images.githubusercontent.com/52242352/211062890-d44537dd-ee86-425a-a276-6b1badc6f50f.png)

![Bildschirmfoto am 2023-01-06 um 18 11 55](https://user-images.githubusercontent.com/52242352/211062895-4bbf2407-00b2-4f12-a1c3-6a50070b694f.png)

After:
![Bildschirmfoto am 2023-01-06 um 18 12 20](https://user-images.githubusercontent.com/52242352/211062907-40b366e7-e245-4bb0-81b1-42c55b10828d.png)

![Bildschirmfoto am 2023-01-06 um 18 12 34](https://user-images.githubusercontent.com/52242352/211062901-b842b392-be2d-490d-8b85-005943862cf1.png)