### PR TITLE
Removeing the unecessary / 's in index.html as it breaks reverse proxying into a sub folder.

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -218,8 +218,8 @@
     <script src="scripts/clipboard.js" async></script>
     <!-- Sounds -->
     <audio id="blop" autobuffer="true">
-        <source src="/sounds/blop.mp3" type="audio/mpeg">
-        <source src="/sounds/blop.ogg" type="audio/ogg">
+        <source src="sounds/blop.mp3" type="audio/mpeg">
+        <source src="sounds/blop.ogg" type="audio/ogg">
     </audio>
     <!-- no script -->
     <noscript>


### PR DESCRIPTION
## Description:
This is just a minor fix, but I found that the /'s before sounds break reverse proxying into a subfolder with traefik.

## Benefits of this PR and context:
It doesn't break any existing functionality and works in the context I tested.

## How Has This Been Tested?
I was initially  using [linuxserver/snapdrop](https://github.com/linuxserver/docker-snapdrop/packages) but then I edited the Dockerfiles to make the build work.

added this line to the Dockerfile

`sed -i 's#/sounds#sounds#g' /app/www/client/index.html && \`

I have tested it on arm64 (raspberry pi 4b+) and amd64.
