### PR TITLE
Use relative path for service worker

### DIFF
--- a/client/scripts/ui.js
+++ b/client/scripts/ui.js
@@ -548,7 +548,7 @@ const snapdrop = new Snapdrop();
 
 
 if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/service-worker.js')
+    navigator.serviceWorker.register('service-worker.js')
         .then(serviceWorker => {
             console.log('Service Worker registered');
             window.serviceWorker = serviceWorker


### PR DESCRIPTION
A minor change that allows the service worker to be loaded properly when the app is not in the root of the URL (e.g. https://example.com/app/snapdrop/). 

Additional to PR https://github.com/RobinLinus/snapdrop/pull/570

It dose not change any behaviour when the app is in the root (e.g. https://example.com)
