### PR TITLE
Add Support For Cloudflare

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -182,8 +182,12 @@ class Peer {
     }
 
     _setIP(request) {
-        if (request.headers['x-forwarded-for']) {
-            this.ip = request.headers['x-forwarded-for'].split(/\s*,\s*/)[0];
+        let xForwarded = request.headers['x-forwarded-for'];
+        let cfIp = request.headers['cf-connecting-ip'];
+        if (cfIp) {
+            this.ip = cfIp;
+        } else if (xForwarded) {
+            this.ip = xForwarded.split(/\s*,\s*/)[0];
         } else {
             this.ip = request.connection.remoteAddress;
         }


### PR DESCRIPTION
Description:
---
This is just a minor fix, when users integrate their website's CDN with Cloudflare, Cloudflare hides the real IP address. As a result, the remoteAddress will always return Cloudflare's own IP address. This can cause Snapdrop to be unable to identify users in the same local network.

Benefits of this PR and context:
---
Enable users to obtain their real IP address while using Cloudflare, without affecting users who are not using Cloudflare.

How Has This Been Tested?
---
I have performed testing on my website s.hoothin.com.
